### PR TITLE
0.2.0 add filter boosting function

### DIFF
--- a/src/search/params/geo_coordinate.rs
+++ b/src/search/params/geo_coordinate.rs
@@ -24,7 +24,6 @@ impl Display for GeoCoordinate {
     }
 }
 
-
 impl Serialize for GeoCoordinate {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/src/search/sort/mod.rs
+++ b/src/search/sort/mod.rs
@@ -252,7 +252,7 @@ mod tests {
                 .coordinates(GeoPoint::Coordinates {
                     latitude: 40.12,
                     longitude: -71.34,
-                },)
+                })
                 .missing("miss"),
             json!({
                 "test": {


### PR DESCRIPTION
### WHAT
* add boosting function with filters

### WHY
current version does not support function in function score query like:
```
    "function_score": {
      "boost_mode": "multiply",
      "functions": [
        {
          "field_value_factor": {
            "factor": 0.05000000074505806,
            "field": "prominence",
            "missing": 0
          },
          "weight": 2
        },
        {
          "gauss": {
            "coordinates": {
              "decay": 0.000009999999747378752,
              "origin": [
                139.7683,
                35.55
              ],
              "scale": "100km"
            }
          },
          "weight": 20
        },
        {
          "filter": {
            "bool": {
              "should": [
                {
                  "term": {
                    "category": {
                      "value": "トラベル>駅"
                    }
                  }
                }
              ]
            }
          },
          "weight": 2
        }
      ],
```